### PR TITLE
feat: add right to left support

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -16,7 +16,7 @@
 
 <body>
     {# Following Menu #}
-    <div class="ui large top fixed hidden menu">
+    <div class="ui large top fixed hidden menu" dir="auto">
         <div class="ui container">
             <a class="header item" href="{{ get_url(path="@/_index.md", lang=lang) | safe }}">
                 {{ trans(key="title", lang=lang) }}
@@ -70,7 +70,7 @@
     </div>
 
     {# Sidebar Menu #}
-    <div class="ui vertical inverted sidebar left menu">
+    <div class="ui vertical inverted sidebar {{ macros::get_current_direction(lang=lang) }} menu">
         <a class="header item" href="{{ get_url(path="@/_index.md", lang=lang) | safe }}">
             {{ trans(key="title", lang=lang) }}
         </a>
@@ -122,7 +122,7 @@
     </div>
 
     {# Page Contents #}
-    <div class="pusher">
+    <div class="pusher" dir="auto">
         <div class="ui inverted vertical masthead center aligned segment">
             <div class="ui container">
                 <div class="ui large secondary inverted pointing menu">

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -6,6 +6,14 @@
     {{ get_section(path=path) | get(key="translations") | filter(attribute="lang", value=lang) | first | get(key="title") }}
 {% endmacro %}
 
+{% macro get_current_direction(lang) %}
+    {% if lang == "ar" %}
+        right
+    {% else %}
+        left
+    {% endif %}
+{% endmacro  %}
+
 {% macro get_current_language(lang) %}
     {% if lang == "en" %}
         English


### PR DESCRIPTION
Add right to left support for menu and content. Side nav have been left
unsupported due to lack of support with dropdown icon.